### PR TITLE
kaminari を使ってページング処理を実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,5 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'carrierwave'
+
+gem 'kaminari', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,18 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -253,6 +265,7 @@ DEPENDENCIES
   carrierwave
   i18n_generators
   jbuilder (~> 2.7)
+  kaminari (~> 1.2)
   listen (~> 3.3)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,7 @@ class BooksController < ApplicationController
   # GET /books
   # GET /books.json
   def index
-    @books = Book.all
+    @books = Book.order(:id).page(params[:page]).per(1)
   end
 
   # GET /books/1

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,5 +1,7 @@
 <p id="notice"><%= notice %></p>
 
+<%= paginate @books %>
+
 <h1><%= Book.model_name.human %></h1>
 
 <table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,13 @@ en:
       delete_confirm: "Are you sure?"
       title_new: "New %{name}"
       title_edit: "Editing %{name}"
+
+    pagination:
+      first: "First"
+      last: "Last"
+      previous: "Prev"
+      next: "Next"
+
   controllers:
     common:
       notice_create: "%{name} was successfully created."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -215,6 +215,13 @@ ja:
       delete_confirm: よろしいですか？
       title_new: "%{name}の新規作成"
       title_edit: "%{name}の編集"
+
+    pagination:
+      first: "最初"
+      last: "最後"
+      previous: "前"
+      next: "次"
+
   controllers:
     common:
       notice_create: "%{name}が作成されました。"


### PR DESCRIPTION
## 必須要件

### 本の一覧ページにページング処理を付ける（1ページあたりの表示件数は任意。要スクリーンショット）

1ページあたり1つの本にしました。

1ページ目
![page_1](https://user-images.githubusercontent.com/43565959/107635008-cb3f5700-6cad-11eb-90c5-608c6b0b1ff8.png)

2ページ目
![page_2](https://user-images.githubusercontent.com/43565959/107635011-cc708400-6cad-11eb-9a18-241c8d979c2f.png)

3ページ目
![page_3](https://user-images.githubusercontent.com/43565959/107635014-cd091a80-6cad-11eb-856e-de2b1004bbe9.png)


### rubocopをパスさせる（要スクリーンショット）
 
```
> bundle exec rubocop
Inspecting 24 files
........................

24 files inspected, no offenses detected
```

## 歓迎要件

### kaminariの"First"や"Last"のような表示を日本語化する

![page_2_en](https://user-images.githubusercontent.com/43565959/107635012-cc708400-6cad-11eb-89e3-4560f14b5ab6.png)
